### PR TITLE
Fix: Ensure '.bd-content.api a' elements

### DIFF
--- a/site/_includes/scripts.html
+++ b/site/_includes/scripts.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
@@ -6,10 +6,15 @@
 {%- if page.layout == "docs" -%}
 <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script>
+  
 $(function () {
-  $('.bd-content.api a').attr('target', '_blank')
-})
+  var apiLinks = $('.bd-content.api a');
+  if (apiLinks.length > 0) {
+    apiLinks.attr('target', '_blank');
+  }
+});
 </script>
+
 {%- endif -%}
 
 {%- if page.layout == "home" -%}
@@ -21,12 +26,10 @@ $(function () {
   window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';
 }(jQuery))</script>
 {%- endif -%}
-
 <script src="https://gg.wenzhixin.net.cn/bootstrap-table/gg.js"></script>
 <script src="{{ site.baseurl }}/assets/js/docs.min.js?m=1"></script>
 
 {% include analytics.html %}
-
 {%- if page.group == "themes" -%}
 {% include themes.html %}
 {%- endif -%}


### PR DESCRIPTION
This PR adds a conditional check for the existence of .bd-content.api a elements before applying the .attr('target', '_blank') method to avoid potential errors.

**🤔Type of Request**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Improvement**
- [ ] **Documentation**
- [ ] **Other**

**🔗Resolves an issue?**
<!-- Please prefix each issue number with  "Fix #"  (e.g. Fix #200)  -->

**📝Changelog**

<!-- The type of the change. --->
- [x] **Core**
- [ ] **Extensions**

<!-- Describe changes from the user side. -->

**💡Example(s)?**
<!-- Please use our online Editor (https://live.bootstrap-table.com/) to create example(s) (Before and after your changes).
On our Wiki (https://github.com/wenzhixin/bootstrap-table/wiki/Online-Editor-Explanation) you can read how to use the editor.-->

**☑️Self Check before Merge**

⚠️ Please check all items below before reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Changelog is provided or not needed

<!-- Love bootstrap-table? Please consider supporting our collective:
👉  https://opencollective.com/bootstrap-table/donate -->
